### PR TITLE
Add !default to _variables.scss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 .IDEA
+dist/

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -2,72 +2,72 @@
 
 // Fonts
 // Credit: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/
-$base-font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto;
-$fallback-font-family: "Helvetica Neue", sans-serif;
-$cjk-font-family: $base-font-family, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Hiragino Kaku Gothic Pro", Meiryo, "Malgun Gothic", $fallback-font-family;
-$body-font-family: $base-font-family, $fallback-font-family;
+$base-font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto !default;
+$fallback-font-family: "Helvetica Neue", sans-serif !default;
+$cjk-font-family: $base-font-family, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Hiragino Kaku Gothic Pro", Meiryo, "Malgun Gothic", $fallback-font-family !default;
+$body-font-family: $base-font-family, $fallback-font-family !default;
 
 // Sizes
-$layout-padding: 1rem;
-$layout-padding-lg: 1.5rem;
-$control-min-width: 18rem;
-$border-radius: .2rem;
-$border-width: .1rem;
+$layout-padding: 1rem !default;
+$layout-padding-lg: 1.5rem !default;
+$control-min-width: 18rem !default;
+$border-radius: .2rem !default;
+$border-width: .1rem !default;
 
 // Colors
 // Core colors
-$primary-color: #5764c6;
-$primary-color-dark: darken($primary-color, 3%);
-$primary-color-light: lighten($primary-color, 3%);
-$secondary-color: lighten($primary-color, 40%);
-$secondary-color-dark: darken($secondary-color, 3%);
-$secondary-color-light: lighten($secondary-color, 3%);
+$primary-color: #5764c6 !default;
+$primary-color-dark: darken($primary-color, 3%) !default;
+$primary-color-light: lighten($primary-color, 3%) !default;
+$secondary-color: lighten($primary-color, 40%) !default;
+$secondary-color-dark: darken($secondary-color, 3%) !default;
+$secondary-color-light: lighten($secondary-color, 3%) !default;
 
-$link-color: $primary-color;
-$link-color-dark: darken($link-color, 10%);
+$link-color: $primary-color !default;
+$link-color-dark: darken($link-color, 10%) !default;
 
 // Gray colors
-$dark-color: #454d5d;
-$light-color: #fff;
-$gray-color: lighten($dark-color, 40%);
-$gray-color-dark: darken($gray-color, 20%);
-$gray-color-light: lighten($gray-color, 20%);
+$dark-color: #454d5d !default;
+$light-color: #fff !default;
+$gray-color: lighten($dark-color, 40%) !default;
+$gray-color-dark: darken($gray-color, 20%) !default;
+$gray-color-light: lighten($gray-color, 20%) !default;
 
-$border-color: lighten($gray-color-light, 3%);
-$border-color-dark: darken($border-color, 15%);
-$bg-color: lighten($dark-color, 66%);
-$bg-color-dark: darken($bg-color, 3%);
-$bg-color-light: $light-color;
+$border-color: lighten($gray-color-light, 3%) !default;
+$border-color-dark: darken($border-color, 15%) !default;
+$bg-color: lighten($dark-color, 66%) !default;
+$bg-color-dark: darken($bg-color, 3%) !default;
+$bg-color-light: $light-color !default;
 
 // Control colors
-$control-color-success: #32b643;
-$control-color-warning: #ffb700;
-$control-color-error: #e85600;
+$control-color-success: #32b643 !default;
+$control-color-warning: #ffb700 !default;
+$control-color-error: #e85600 !default;
 
 // Other colors
-$code-color: #e06870;
-$highlight-color: #ffe9b3;
+$code-color: #e06870 !default;
+$highlight-color: #ffe9b3 !default;
 
 // Global
-$html-font-size: 10px;
-$html-line-height: 1.428571429;
-$body-bg: $bg-color-light;
-$body-font-color: lighten($dark-color, 5%);
-$font-size: 1.4rem;
-$font-size-sm: 1.2rem;
-$font-size-lg: 1.6rem;
+$html-font-size: 10px !default;
+$html-line-height: 1.428571429 !default;
+$body-bg: $bg-color-light !default;
+$body-font-color: lighten($dark-color, 5%) !default;
+$font-size: 1.4rem !default;
+$font-size-sm: 1.2rem !default;
+$font-size-lg: 1.6rem !default;
 
 // Responsive breakpoints
-$size-xs: 480px;
-$size-sm: 600px;
-$size-md: 840px;
-$size-lg: 960px;
-$size-xl: 1280px;
-$size-2x: 1440px;
+$size-xs: 480px !default;
+$size-sm: 600px !default;
+$size-md: 840px !default;
+$size-lg: 960px !default;
+$size-xl: 1280px !default;
+$size-2x: 1440px !default;
 
 // Z-index
-$zindex-0: 1;
-$zindex-1: 100;
-$zindex-2: 200;
-$zindex-3: 300;
-$zindex-4: 400;
+$zindex-0: 1 !default;
+$zindex-1: 100 !default;
+$zindex-2: 200 !default;
+$zindex-3: 300 !default;
+$zindex-4: 400 !default;

--- a/test-defaults.scss
+++ b/test-defaults.scss
@@ -1,0 +1,3 @@
+$primary-color: #FFA500;
+
+@import "spectre.scss";


### PR DESCRIPTION
Adding `!default` to each SASS variable allows it to be overwritten in order to create custom themes with libraries. Added an example of this in `test-defaults.scss`

See: https://robots.thoughtbot.com/sass-default